### PR TITLE
Ci(hedera-mirror-rosetta): Update Dockerfile + modules

### DIFF
--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -58,7 +58,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Mirror Node All-in-One
         run: docker build --tag=${{env.image-tag}} -f hedera-mirror-rosetta/scripts/validation/Dockerfile .
-        working-directory: .
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 ${{env.image-tag}}
       - name: Wait for Mirror Node to start syncing

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -42,8 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build Mirror Node
-        run: docker build --tag=${{env.image-tag}} .
+      - name: Build Mirror Node All-in-One
+        run: docker build --tag=${{env.image-tag}} -f hedera-mirror-rosetta/scripts/validation/Dockerfile .
         working-directory: ${{env.working-directory}}/build
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 ${{env.image-tag}}

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -15,6 +15,13 @@ jobs:
         name: Setup GO Env
         with:
           go-version: '1.13'
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - name: Build hedera-mirror-rosetta
         run: go build -i -o rosetta cmd/*
         working-directory: ${{env.working-directory}}

--- a/.github/workflows/rosetta-api.yml
+++ b/.github/workflows/rosetta-api.yml
@@ -39,6 +39,13 @@ jobs:
         name: Setup GO Env
         with:
           go-version: '1.13'
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-test-
       - name: Run Unit Tests with Coverage
         run: go test ./... -coverpkg=./... -race -coverprofile=coverage.txt -covermode=atomic
         working-directory: ${{env.working-directory}}
@@ -51,7 +58,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Mirror Node All-in-One
         run: docker build --tag=${{env.image-tag}} -f hedera-mirror-rosetta/scripts/validation/Dockerfile .
-        working-directory: ${{env.working-directory}}/build
+        working-directory: .
       - name: Run Mirror Node
         run: docker run -d -p 5700:5700 ${{env.image-tag}}
       - name: Wait for Mirror Node to start syncing

--- a/hedera-mirror-rosetta/scripts/validation/Dockerfile
+++ b/hedera-mirror-rosetta/scripts/validation/Dockerfile
@@ -1,0 +1,87 @@
+# This Dockerfile configuration is used to build
+# Importer, Rosetta and PostgreSQL into one image
+# and run the services using supervisord locally
+# (upon build, target folder must be hedera-mirror-node)
+
+# ------------------------------  Rosetta  ------------------------------- #
+FROM golang:1.13 as rosetta-builder
+WORKDIR /tmp
+COPY . ./hedera-mirror-node
+WORKDIR /tmp/hedera-mirror-node/hedera-mirror-rosetta
+RUN go build -o rosetta-executable ./cmd
+
+# ---------------------------- Importer/GRPC ----------------------------- #
+FROM openjdk:11.0 as java-builder
+
+RUN apt-get update && apt-get install -y git
+COPY . ./hedera-mirror-node
+RUN cd hedera-mirror-node && ./mvnw clean package -DskipTests
+
+# ######################################################################## #
+# --------------------------- Runner Container --------------------------- #
+# ######################################################################## #
+
+FROM ubuntu:18.04 as runner
+
+# ---------------------- Install Deps & PosgreSQL ------------------------ #
+# Add the PostgreSQL PGP key to verify their Debian packages.
+# It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
+RUN apt-get update && apt-get install -y gnupg
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+
+# Add PostgreSQL's repository. It contains the most recent stable release
+#  of PostgreSQL.
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
+# Install PostgreSQL 9.6, supervisor, git and openjdk-11
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y postgresql-9.6 postgresql-client-9.6 postgresql-contrib-9.6 supervisor git openjdk-11-jdk-headless curl
+
+USER root
+
+# Create Volume PostgreSQL directory and Change default PostgreSQL directory
+RUN mkdir -p /data/db
+RUN chown postgres /data/db
+RUN chmod 700 /data/db
+RUN mv /var/lib/postgresql/9.6/main /data/db/main
+RUN ln -s /data/db/main /var/lib/postgresql/9.6/main
+
+# ---------------------------  Supervisord  --------------------------- #
+
+# Clone the Repo
+COPY . ./hedera-mirror-node
+
+USER postgres
+
+# Init db script
+RUN /etc/init.d/postgresql start &&\
+    createdb mirror_node &&\
+    psql --command "create user mirror_node with SUPERUSER password 'mirror_node_pass'"&&\
+    POSTGRES_DB=mirror_node /hedera-mirror-node/hedera-mirror-grpc/scripts/db/init.sh
+
+# And add ``listen_addresses`` to ``/etc/postgresql/9.6/main/postgresql.conf``
+RUN echo "listen_addresses='*'" >> /etc/postgresql/9.6/main/postgresql.conf
+# Allow PG Admin access
+RUN echo "host    all             all             172.17.0.1/16           trust" >> /etc/postgresql/9.6/main/pg_hba.conf
+
+USER root
+
+# Create Volume importer directory
+RUN mkdir -p /data/data
+RUN ln -s /data/data /hedera-mirror-node
+
+# Copy the Rosetta Executable from the Rosetta Builder stage
+WORKDIR /var/rosetta
+COPY --from=rosetta-builder /tmp/hedera-mirror-node/hedera-mirror-rosetta/rosetta-executable .
+COPY --from=rosetta-builder /tmp/hedera-mirror-node/hedera-mirror-rosetta/config/application.yml ./config/application.yml
+
+# Copy the Importer Jar and Config from the Java-Builder stage
+WORKDIR /var/importer
+COPY --from=java-builder /hedera-mirror-node/hedera-mirror-importer/target/hedera-mirror-importer-*exec.jar ./hedera-mirror-importer.jar
+COPY --from=java-builder /hedera-mirror-node/hedera-mirror-importer/src/main/resources/application.yml .
+
+WORKDIR /hedera-mirror-node/hedera-mirror-rosetta/build
+# Expose the ports
+# (DB)(Rosetta)
+EXPOSE 5432 5700
+ENTRYPOINT [ "./run_supervisord.sh" ]


### PR DESCRIPTION
**Detailed description**:
* Cache Go Modules on `build` and `test`
* Add separate All-in-One Dockerfile only for validation (instead of cloning the repository, it uses the current state)

**Which issue(s) this PR fixes**:
Fixes #None

**Checklist**
- [ ] Documentation added
- [ ] Tests updated

